### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,15 +4,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AsyncTimer KEYWORD1
+AsyncTimer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-start   KEYWORD2
-kill    KEYWORD2
-checkExpiration   KEYWORD2
+start	KEYWORD2
+kill	KEYWORD2
+checkExpiration	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords